### PR TITLE
Bugfix se configurable ores 5 betterstone terraremake

### DIFF
--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -1721,11 +1721,16 @@ namespace ConfigurableOres
                     WriteToChat(Format(CHAT_HELP_ORE_ADD_SUCCESS, ore, planetName, rarity));
                     return true;
                 }
+                else
+                {
+                    WriteToChat(CHAT_HELP_ORE_ADD_FAILED);
+                    return false;
+                }
 
                 break;
             }
 
-            WriteToChat(CHAT_HELP_ORE_ADD_FAILED);
+            WriteToChat(CHAT_HELP_ORE_ADD_NOTFOUND);
             return true;
         }
 

--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -489,7 +489,7 @@ namespace ConfigurableOres
 
                 //menuText.AppendLine(Format(CHAT_MENU_HINT_PLANETS, BreadCrumb(breadcrumbs, CHAT_MENU_ITEM_PLANETS)));
 
-                menuText.AppendLine(NiceList(Config.MyPlanetConfigurations.GetNames(), true));
+                menuText.AppendLine(NiceList(Config.MyPlanetConfigurations.GetNames()));
                 /*foreach (var planetName in Config.MyPlanetConfigurations.GetNames())
                 {
                     menuText.AppendLine(Format(CHAT_MENU_HINT_PLANET_KNOWN, breadcrumbs, planetName));

--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -119,7 +119,7 @@ namespace ConfigurableOres
                 if (!Config.DisableChatCommands)
                 {
                     MyAPIGateway.Utilities.MessageEnteredSender += ChatHandler;
-                    WriteToChat(Format(CHAT_HELLO_COMMANDS_ENABLED, Config.CommandPrefix));
+                    WriteToChat(Format(CHAT_HELLO_COMMANDS_ENABLED, COMMAND_PREFIX));
                 }
             }
 
@@ -456,14 +456,10 @@ namespace ConfigurableOres
 
             // Chat fuse burned
             if (Config.DisableChatCommands) return;
+            
+            if (!IsMyMatch(COMMAND_PREFIX, messageText)) return;
 
-            // todo: implement modifying command prefix
-            //var wakeword = DEFAULT_COMMAND_CHAR + Config.CommandPrefix;
-            //LogVar("wakeword", wakeword);
-
-            if (!IsMyMatch(Config.CommandPrefix, messageText)) return;
-
-            if (!MenuRoot(Config.CommandPrefix, RegexTrim(Config.CommandPrefix, messageText)))
+            if (!MenuRoot(COMMAND_PREFIX, TrimMyMatch(COMMAND_PREFIX, messageText)))
                 WriteErrorToChat(Error("default"), messageText);
         }
 
@@ -571,7 +567,7 @@ namespace ConfigurableOres
             // Example command: /ore alien del uranium
             //menuText.Append(NEWLINE);
             //CommandHints.ShuffleList();
-            //menuText.AppendLine(Format(CHAT_MENU_ROOT_HINT_EXAMPLE, Config.CommandPrefix, CommandHints.FirstOrDefault()));
+            //menuText.AppendLine(Format(CHAT_MENU_ROOT_HINT_EXAMPLE, COMMAND_PREFIX, CommandHints.FirstOrDefault()));
 
             WriteToChat(menuText.ToString());
             return true;

--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -477,7 +477,7 @@ namespace ConfigurableOres
             // World
             if (IsMyMatch(Item("world"), message))
             {
-                return MenuWorld(breadcrumbs, RegexTrim(Item("world"), message));
+                return MenuWorld(breadcrumbs, TrimMyMatch(Item("world"), message));
             }
 
             // List Planets
@@ -523,7 +523,7 @@ namespace ConfigurableOres
                     return false;
                 }
 
-                return MenuPlanet(breadcrumbs, planetName, RegexTrim(planetName, message));
+                return MenuPlanet(breadcrumbs, planetName, TrimMyMatch(planetName, message));
             }
 
             return false;
@@ -622,31 +622,31 @@ namespace ConfigurableOres
             // Mod settings
             if (IsMyMatch(Item("mod"), message))
             {
-                return MenuWorldModSettings(breadcrumbs, RegexTrim(Item("mod"), message));
+                return MenuWorldModSettings(breadcrumbs, TrimMyMatch(Item("mod"), message));
             }
 
             // Depth
             if (IsMyMatch(Item("depth"), message))
             {
-                return MenuAutoDepth(breadcrumbs, RegexTrim(Item("depth"), message));
+                return MenuAutoDepth(breadcrumbs, TrimMyMatch(Item("depth"), message));
             }
 
             // Size
             if (IsMyMatch(Item("size"), message))
             {
-                return MenuAutoSize(breadcrumbs, RegexTrim(Item("size"), message));
+                return MenuAutoSize(breadcrumbs, TrimMyMatch(Item("size"), message));
             }
 
             // Ignored Planets
             if (IsMyMatch(Item("world_ignored_planets"), message))
             {
-                return MenuIgnoredPlanets(breadcrumbs, RegexTrim(Item("world_ignored_planets"), message));
+                return MenuIgnoredPlanets(breadcrumbs, TrimMyMatch(Item("world_ignored_planets"), message));
             }
 
             // Static Voxel Materials
             if (IsMyMatch(Item("world_static_voxel_mats"), message))
             {
-                return MenuStaticVoxelMats(breadcrumbs, RegexTrim(Item("world_static_voxel_mats"), message));
+                return MenuStaticVoxelMats(breadcrumbs, TrimMyMatch(Item("world_static_voxel_mats"), message));
             }
 
             // Hidden
@@ -1261,14 +1261,14 @@ namespace ConfigurableOres
             // Add an ore
             if (IsMyMatch(Item("add"), message))
             {
-                message = RegexTrim(Item("add"), message);
+                message = TrimMyMatch(Item("add"), message);
                 return MenuPlanetAddOre(breadcrumbs, planetName, message);
             }
 
             // Remove an ore
             if (IsMyMatch(Item("del"), message))
             {
-                message = RegexTrim(Item("del"), message);
+                message = TrimMyMatch(Item("del"), message);
                 return MenuPlanetDelOre(breadcrumbs, planetName, message);
             }
 
@@ -1289,7 +1289,7 @@ namespace ConfigurableOres
             if (IsMyMatch(Item("depth"), message))
             {
                 var item = Item("depth");
-                message = RegexTrim(item, message);
+                message = TrimMyMatch(item, message);
                 return MenuPlanetAutoDepth(breadcrumbs, planetName, message);
             }
 
@@ -1297,7 +1297,7 @@ namespace ConfigurableOres
             if (IsMyMatch(Item("size"), message))
             {
                 var item = Item("size");
-                message = RegexTrim(item, message);
+                message = TrimMyMatch(item, message);
                 return MenuPlanetAutoSize(breadcrumbs, planetName, message);
             }
 
@@ -1306,7 +1306,7 @@ namespace ConfigurableOres
             {
                 if (!IsMyMatch(oreName, message)) continue;
 
-                message = RegexTrim(oreName, message);
+                message = TrimMyMatch(oreName, message);
                 return MenuPlanetOre(breadcrumbs, oreName, planetName, message);
             }
 
@@ -1701,7 +1701,7 @@ namespace ConfigurableOres
             {
                 if (!IsMyMatch(ore, message)) continue;
 
-                message = RegexTrim(ore, message);
+                message = TrimMyMatch(ore, message);
 
                 var rarity = planet.MeanRarity;
 
@@ -1912,14 +1912,14 @@ namespace ConfigurableOres
             // AutoDepth
             if (IsMyMatch(Item("depth"), message))
             {
-                message = RegexTrim(Item("depth"), message);
+                message = TrimMyMatch(Item("depth"), message);
                 return MenuPlanetOreAutoDepth(breadcrumbs, oreName, planetName, message);
             }
 
             // AutoSize
             if (IsMyMatch(Item("size"), message))
             {
-                message = RegexTrim(Item("size"), message);
+                message = TrimMyMatch(Item("size"), message);
                 return MenuPlanetOreAutoSize(breadcrumbs, oreName, planetName, message);
             }
 
@@ -2370,7 +2370,7 @@ namespace ConfigurableOres
 
         private static MyTuple<bool, bool> ChatParseBool(string command, string message)
         {
-            message = RegexTrim(command, message);
+            message = TrimMyMatch(command, message);
             if (message.Length < 1) return new MyTuple<bool, bool>(false, false);
 
             bool tmp;
@@ -2387,7 +2387,7 @@ namespace ConfigurableOres
 
         private static MyTuple<bool, float> ChatParsePositiveFloat(string command, string message)
         {
-            message = RegexTrim(command, message);
+            message = TrimMyMatch(command, message);
             if (message.Length < 1) return new MyTuple<bool, float>(false, 0);
 
             float tmp;
@@ -2406,7 +2406,7 @@ namespace ConfigurableOres
 
         private static MyTuple<bool, int> ChatParsePositiveInt(string command, string message)
         {
-            message = RegexTrim(command, message);
+            message = TrimMyMatch(command, message);
             if (message.Length < 1) return new MyTuple<bool, int>(false, 0);
 
             int tmp;
@@ -2425,7 +2425,7 @@ namespace ConfigurableOres
 
         private static MyTuple<bool, MyCubeSize> ChatParseCubeSize(string command, string message)
         {
-            message = RegexTrim(command, message);
+            message = TrimMyMatch(command, message);
             if (message.Length < 1) return new MyTuple<bool, MyCubeSize>(false, Large);
 
             MyCubeSize tmp;

--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -725,7 +725,6 @@ namespace ConfigurableOres
             if (IsMyMatch(Item("reset"), message))
             {
                 var item = Item("reset");
-                Config.CommandPrefix = DEFAULT_COMMAND_PREFIX;
                 Config.Logging = DEFAULT_LOGGING_ENABLED;
                 Save(Config);
                 WriteConfirmationToChat("settings", item, "actions");

--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -506,7 +506,7 @@ namespace ConfigurableOres
 
                 menuText.AppendLine(Format(CHAT_MENU_HEADER_TOP, Format(Hint("root_ores"), breadcrumbs)));
 
-                menuText.AppendLine(NiceList(VoxelOres.GetUsableOres(), true));
+                menuText.AppendLine(NiceList(VoxelOres.GetUsableOres()));
 
                 WriteToChat(menuText.ToString());
                 return true;

--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -2337,7 +2337,7 @@ namespace ConfigurableOres
         {
             /*
              * Filter out static voxel materials so we don't mess with the weird
-             * stuff some Planets do with the oremappings, for example Mars's "Ice" voxelmaterial
+             * stuff some Planets do with the oremappings, for example Mars's "Ice" VoxelMaterial
              */
 
             var tmpList = new List<string>();

--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -1709,7 +1709,7 @@ namespace ConfigurableOres
 
                 var rarity = planet.MeanRarity;
 
-                // OK if this fails, just means a value for rarity wasn't passed or parsed.
+                // Skip parsing rarity if nothing left to parse
                 if (message.Length > 0)
                 {
                     if (!float.TryParse(message, out rarity))

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -47,8 +47,9 @@ namespace ConfigurableOres
         public static bool LOGGING_ENABLED = false;
         public static bool DEFAULT_LOGGING_ENABLED = false;
         
-        public const string DEFAULT_COMMAND_CHAR = "/";
-        public const string DEFAULT_COMMAND_PREFIX = "/ore";
+        public const string COMMAND_PREFIX = "/ore";
+        public const string MENU_REGEX_PREFIX = "(?i)^";
+        public const string MENU_REGEX_SUFFIX = "\\s*";
         public const float DEFAULT_OREMAP_DEPTH_START = 15f;
         public const float DEFAULT_OREMAP_DEPTH_SIZE = 1f;
         public const string DEFAULT_OREMAP_TARGETCOLOR = "#616c83";

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -273,11 +273,6 @@ namespace ConfigurableOres
             return match.IsMatch(text);
         }
 
-        /*public static string RegexTrim(Regex match, string text)
-        {
-            return RegexTrim(match.ToString(), text);
-        }*/
-
         public static string RegexTrim(string match, string text)
         {
             return Regex.Replace(text, CHAT_REGEX_PREFIX + match, "", RegexOptions.IgnoreCase).Trim();

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -48,9 +48,9 @@ namespace ConfigurableOres
         // Whether or not to throw() up on errors
         public const bool ABEND_ON_FAULT = true;
         // Whether or not logging is enabled immediately
-        public static bool LOGGING_ENABLED = true;
+        public static bool LOGGING_ENABLED = false;
         // Whether or not default new config enables logging
-        public static bool DEFAULT_LOGGING_ENABLED = true;
+        public static bool DEFAULT_LOGGING_ENABLED = false;
         // ------------------------------
         
         public const string COMMAND_PREFIX = "/ore";

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -262,6 +262,13 @@ namespace ConfigurableOres
 
         #region Menu Helpers
 
+        public static string MenuRegexBuilder(string match)
+        {
+            var regexString = $"{MENU_REGEX_PREFIX}{Regex.Escape(match)}{MENU_REGEX_SUFFIX}";
+            LogVar("MenuRegexBuilder", "regexString", regexString);
+            return regexString;
+        }
+        
         public static bool IsMyMatch(string match, string text)
         {
             var _regex = new Regex("(?i)^" + match);

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -271,18 +271,20 @@ namespace ConfigurableOres
         
         public static bool IsMyMatch(string match, string text)
         {
-            var _regex = new Regex("(?i)^" + match);
-            return IsMyMatch(_regex, text);
-        }
+            LogVar("IsMyMatch", "match", match);
+            LogVar("IsMyMatch", "text", text);
+            
+            var matchRegex = new Regex(MenuRegexBuilder(match));
 
-        public static bool IsMyMatch(Regex match, string text)
-        {
-            return match.IsMatch(text);
+            return matchRegex.IsMatch(text);
         }
 
         public static string TrimMyMatch(string match, string text)
         {
-            return Regex.Replace(text, CHAT_REGEX_PREFIX + match, "", RegexOptions.IgnoreCase).Trim();
+            LogVar("RegexTrim", "match", match);
+            LogVar("RegexTrim", "text", text);
+
+            return Regex.Replace(text, MenuRegexBuilder(match), "", RegexOptions.IgnoreCase).Trim();
         }
 
         public static string ClarifyBoolString(string text)

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -42,10 +42,16 @@ namespace ConfigurableOres
         //  TODO [DEBUG] -- Set to false before publishing
         public const string CONFIG_FILE_NAME = "ConfigurableOres.xml";
 
-        // TODO: set to false on release.
+        // ------------------------------
+        // TODO: Set these to false on release.
+        // ------------------------------
+        // Whether or not to throw() up on errors
         public const bool ABEND_ON_FAULT = true;
-        public static bool LOGGING_ENABLED = false;
-        public static bool DEFAULT_LOGGING_ENABLED = false;
+        // Whether or not logging is enabled immediately
+        public static bool LOGGING_ENABLED = true;
+        // Whether or not default new config enables logging
+        public static bool DEFAULT_LOGGING_ENABLED = true;
+        // ------------------------------
         
         public const string COMMAND_PREFIX = "/ore";
         public const string MENU_REGEX_PREFIX = "(?i)^";

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -280,7 +280,7 @@ namespace ConfigurableOres
             return match.IsMatch(text);
         }
 
-        public static string RegexTrim(string match, string text)
+        public static string TrimMyMatch(string match, string text)
         {
             return Regex.Replace(text, CHAT_REGEX_PREFIX + match, "", RegexOptions.IgnoreCase).Trim();
         }

--- a/Data/Scripts/ConfigurableOres/ModInfo.cs
+++ b/Data/Scripts/ConfigurableOres/ModInfo.cs
@@ -39,7 +39,7 @@ namespace ConfigurableOres
         private const int RELEASE_NUMBER = 1;
         private const int MAJOR_VERSION = 0;
         private const int MINOR_VERSION = 14;
-        private const int BUILD_NUMBER = 0;
+        private const int BUILD_NUMBER = 5;
 
         public static readonly Version Version = new Version(
             major: RELEASE_NUMBER,

--- a/Data/Scripts/ConfigurableOres/ModInfo.cs
+++ b/Data/Scripts/ConfigurableOres/ModInfo.cs
@@ -39,7 +39,7 @@ namespace ConfigurableOres
         private const int RELEASE_NUMBER = 1;
         private const int MAJOR_VERSION = 0;
         private const int MINOR_VERSION = 14;
-        private const int BUILD_NUMBER = 5;
+        private const int BUILD_NUMBER = 05;
 
         public static readonly Version Version = new Version(
             major: RELEASE_NUMBER,

--- a/Data/Scripts/ConfigurableOres/PersistentConfiguration.cs
+++ b/Data/Scripts/ConfigurableOres/PersistentConfiguration.cs
@@ -44,7 +44,7 @@ namespace ConfigurableOres
 
         // System
         public bool Logging;
-        public string CommandPrefix;
+        //public string CommandPrefix = "";
         public bool DisableChatCommands;
 
         // OreAutoDepth
@@ -233,7 +233,6 @@ namespace ConfigurableOres
             var isValid = true;
             var reason = "";
 
-            isValid &= !string.IsNullOrWhiteSpace(CommandPrefix);
             if (!isValid) return new MyTuple<bool, string>(isValid, "CommandPrefix IsNullOrWhiteSpace");
 
             isValid &= (Depth.Fuzz > 0);
@@ -315,7 +314,6 @@ namespace ConfigurableOres
             LogBegin(LOG_CREATE_DEFAULT_CONFIGURATION);
 
             DisableChatCommands = false;
-            CommandPrefix = DEFAULT_COMMAND_PREFIX;
 
             // TODO: set this to false before release!!!
             Logging = DEFAULT_LOGGING_ENABLED;

--- a/Data/Scripts/ConfigurableOres/Strings.cs
+++ b/Data/Scripts/ConfigurableOres/Strings.cs
@@ -679,6 +679,7 @@ namespace ConfigurableOres
         public const string CHAT_HELP_ORE_HEADER = " {0} - {1} Settings (read the guide)";
         public const string CHAT_HELP_ORE_ADD_LIST = " Unassigned Ores";
         public const string CHAT_HELP_ORE_ADD_FAILED = "Add failed: duplicate ore or no free slots";
+        public const string CHAT_HELP_ORE_ADD_NOTFOUND = "Add failed: requested ore not found in list. Use \"/ore ores\" to get list of available ores.";
         public static string CHAT_HELP_ORE_ADD_SUCCESS = "{0} added to {1} with rarity {2}";
 
         public static string CHAT_HELP_ORE_ADD_FAILED_WITH_RARITY =

--- a/Data/Scripts/ConfigurableOres/Strings.cs
+++ b/Data/Scripts/ConfigurableOres/Strings.cs
@@ -592,8 +592,6 @@ namespace ConfigurableOres
 
         #region ChatUI Menuing
 
-        public const string CHAT_REGEX_PREFIX = "(?i) *^";
-
         public const string CHAT_MENU_PREFIX_HEADER_TOP = ">>>";
         public const string CHAT_MENU_PREFIX_HEADER_COMMANDS = "==";
         public const string CHAT_LINE_THICK = "===========================================";


### PR DESCRIPTION
Rewrote the command parser logic to wrap ore names in Regex.Escape().

Created and implemented a new MenuRegexBuilder() method which should be used anywhere chat commands must be parsed.  

Opened #7 to ensure this was correctly applied to planet name parsing.

Closes #5 

---
