### PR TITLE
bugfix: mod menu logging toggle doesnt work

### DIFF
--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -741,7 +741,7 @@ namespace ConfigurableOres
                 var parsed = ChatParseBool(item, message);
                 if (!parsed.Item1) return false;
 
-                Config.Logging = parsed.Item2;
+                LOGGING_ENABLED = Config.Logging = parsed.Item2;
                 WriteConfirmationToChat(item, parsed.Item2);
 
                 Save(Config);

--- a/Data/Scripts/ConfigurableOres/ModInfo.cs
+++ b/Data/Scripts/ConfigurableOres/ModInfo.cs
@@ -39,7 +39,7 @@ namespace ConfigurableOres
         private const int RELEASE_NUMBER = 1;
         private const int MAJOR_VERSION = 0;
         private const int MINOR_VERSION = 14;
-        private const int BUILD_NUMBER = 05;
+        private const int BUILD_NUMBER = 052;
 
         public static readonly Version Version = new Version(
             major: RELEASE_NUMBER,

--- a/Data/Scripts/ConfigurableOres/ModInfo.cs
+++ b/Data/Scripts/ConfigurableOres/ModInfo.cs
@@ -34,7 +34,7 @@ namespace ConfigurableOres
         /// Release: write / rewrite
         /// Major version: updates / new features -- compatability may break
         /// Minor version: minor changes / bugfixes -- backwards compatibility maintained
-        /// Build: build - no CI/CD, not used.
+        /// Build: build - append issue # to BUILD_NUMBER.
         /// </summary>
         private const int RELEASE_NUMBER = 1;
         private const int MAJOR_VERSION = 0;

--- a/Data/Scripts/ConfigurableOres/Strings.cs
+++ b/Data/Scripts/ConfigurableOres/Strings.cs
@@ -435,7 +435,7 @@ namespace ConfigurableOres
             AddMenu("mod", "Mod", "Edit mod settings");
             AddItem("mod_summary", "Mod");
             AddHelp("mod_summary", "These settings modify core mod behaviors such as logging.");
-            AddMenu("mod_logging", "Logging <On/Off>", "Enable logging?");
+            AddMenu("mod_logging", "Logging", "<On/Off>: Enable or disable logging");
             AddHelp("mod_logging",
                 $"{Item("mod_logging")}: This setting enables or disables writing debug messages to the Space Engineers log file. This mod produces a lot of logging messages, so leave logging disabled unless you are troubleshooting.");
             AddMenu("mod_command_prefix", "CommandPrefix", "Set the command prefix (default \"/ore\")");


### PR DESCRIPTION
The match string for the logging setting contained value hints so the command would always fail.  Those hints were moved into the command description where they belong.  Works now.

Also made sure the LOGGING_ENABLED global flag is set simultaneously with the config file, which is set as soon as the command is executed.

Closes #2