### PR TITLE
Applied GPLv3 headers to source files

### DIFF
--- a/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
+++ b/Data/Scripts/ConfigurableOres/ConfigurableOres.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+    Configurable Ores - A Space Engineers mod for managing planetary ores.
+    Copyright 2022 Travis Wichert
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/Data/Scripts/ConfigurableOres/Helpers.cs
+++ b/Data/Scripts/ConfigurableOres/Helpers.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+    Configurable Ores - A Space Engineers mod for managing planetary ores.
+    Copyright 2022 Travis Wichert
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/Data/Scripts/ConfigurableOres/ModInfo.cs
+++ b/Data/Scripts/ConfigurableOres/ModInfo.cs
@@ -1,3 +1,21 @@
+/*
+    Configurable Ores - A Space Engineers mod for managing planetary ores.
+    Copyright 2022 Travis Wichert
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -39,7 +57,7 @@ namespace ConfigurableOres
         private const int RELEASE_NUMBER = 1;
         private const int MAJOR_VERSION = 0;
         private const int MINOR_VERSION = 14;
-        private const int BUILD_NUMBER = 052;
+        private const int BUILD_NUMBER = 0524;
 
         public static readonly Version Version = new Version(
             major: RELEASE_NUMBER,

--- a/Data/Scripts/ConfigurableOres/PersistentConfiguration.cs
+++ b/Data/Scripts/ConfigurableOres/PersistentConfiguration.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+    Configurable Ores - A Space Engineers mod for managing planetary ores.
+    Copyright 2022 Travis Wichert
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/Data/Scripts/ConfigurableOres/PlanetConfiguration.cs
+++ b/Data/Scripts/ConfigurableOres/PlanetConfiguration.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+    Configurable Ores - A Space Engineers mod for managing planetary ores.
+    Copyright 2022 Travis Wichert
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using System;
 using System.Collections;
 using System.Runtime;
 using System.Collections.Generic;

--- a/Data/Scripts/ConfigurableOres/Strings.cs
+++ b/Data/Scripts/ConfigurableOres/Strings.cs
@@ -1,3 +1,21 @@
+/*
+    Configurable Ores - A Space Engineers mod for managing planetary ores.
+    Copyright 2022 Travis Wichert
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
GPLv3 source headers were applied to all `.cs` files.

Closes #4
